### PR TITLE
chore(tests): Cleanup bootstrap.php to be forward-compatible

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -17,5 +17,3 @@ require_once __DIR__ . '/../../../tests/autoload.php';
 require_once __DIR__ . '/../vendor/autoload.php';
 
 Server::get(IAppManager::class)->loadApp('limit_login_to_ip');
-
-OC_Hook::clear();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,16 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+use OCP\App\IAppManager;
+use OCP\Server;
+
 define('PHPUNIT_RUN', 1);
 
 require_once __DIR__ . '/../../../lib/base.php';
+require_once __DIR__ . '/../../../tests/autoload.php';
 require_once __DIR__ . '/../vendor/autoload.php';
 
-\OC::$loader->addValidRoot(OC::$SERVERROOT . '/tests');
-\OC_App::loadApp('limit_login_to_ip');
+Server::get(IAppManager::class)->loadApp('limit_login_to_ip');
 
 OC_Hook::clear();


### PR DESCRIPTION
This uses the new tests/autoload.php from nextcloud/server instead of messing directly with OC private autoloader.

See https://github.com/nextcloud/server/pull/52951 and https://github.com/nextcloud/server/pull/52945 for context.