### PR TITLE
fix: build frontend assets when packaging the app

### DIFF
--- a/.nextcloudignore
+++ b/.nextcloudignore
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
+.editorconfig
 .git
 .github
 .gitignore
@@ -11,9 +12,15 @@
 CHANGELOG.md
 composer.json
 composer.lock
+eslint.config.js
 krankerl.toml
 Makefile
+node_modules
+package-lock.json
+package.json
 psalm.xml
+rector.php
+src
 tests
 vendor-bin
-
+vite.config.ts

--- a/krankerl.toml
+++ b/krankerl.toml
@@ -3,4 +3,6 @@
 [package]
 before_cmds = [
 	"composer install --no-dev -o",
+	"npm ci",
+	"npm run build",
 ]


### PR DESCRIPTION
## Summary

The Vue 3 migration (#115) forgot to add a frontend build command to the packaging step, so the released app store package ships without the assets and the admin settings page 404s on its CSS/JS.

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI